### PR TITLE
feat: Add basic rate limiting

### DIFF
--- a/.clinerules/project_guidelines.md
+++ b/.clinerules/project_guidelines.md
@@ -43,7 +43,7 @@ These guidelines ensure consistency, maintainability, and quality across the pro
 6.3. **Input Sanitization:** While `express-validator` helps, be mindful of potential security risks. Use parameterized queries (as handled by `sqlite3` placeholders `?`) to prevent SQL injection. Avoid constructing SQL queries directly with user input.
 6.4. **Dependencies:** Keep dependencies updated (`npm update`). Regularly audit dependencies for known vulnerabilities (`npm audit`).
 6.5. **Helmet:** Ensure `helmet` middleware is used in `index.js` for basic security headers.
-6.6. **Rate Limiting:** Consider adding rate limiting middleware (e.g., `express-rate-limit`) for production environments to prevent abuse.
+6.6. **Rate Limiting:** Basic rate limiting (`express-rate-limit`) is applied globally in `index.js` to prevent abuse. Adjust configuration as needed for specific environments or routes.
 
 ## 7. Testing
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ erDiagram
 
 All API endpoints require an API key for authentication. The API key must be sent in the `X-API-Key` header with each request.
 
+## Rate Limiting
+
+To prevent abuse, API requests are rate-limited. By default, each IP address is allowed 100 requests per 15-minute window. If the limit is exceeded, a `429 Too Many Requests` error will be returned.
+
 ## Prerequisites
 
 - Node.js (v16 or later recommended)

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
 const habitRoutes = require('./src/api/habits.routes');
 const errorHandler = require('./src/middlewares/errorHandler');
 const { NotFoundError } = require('./src/utils/errors');
@@ -28,6 +29,15 @@ app.use(
 app.use(helmet());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+
+const limiter = rateLimit({
+  windowMs: process.env.RATE_LIMIT_WINDOW_MS || 15 * 60 * 1000,
+  max: process.env.RATE_LIMIT_MAX_REQUESTS || 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: `Too many requests from this IP, please try again after ${Math.round(rateLimitWindowMs / 60000)} minutes`,
+});
+app.use('/api', limiter);
 
 app.use('/api/v1/habits', habitRoutes);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.0",
         "express-validator": "^7.2.1",
         "helmet": "^8.0.0",
         "knex": "^3.1.0",
@@ -2006,6 +2007,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express-validator": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^4.21.2",
+    "express-rate-limit": "^7.5.0",
     "express-validator": "^7.2.1",
     "helmet": "^8.0.0",
     "knex": "^3.1.0",


### PR DESCRIPTION
This PR introduces basic API rate limiting using `express-rate-limit`.

Changes include:
- Installed `express-rate-limit` dependency.
- Applied rate limiting middleware globally in `index.js` to routes starting with `/api`.
- Updated `README.md` and `.clinerules/project_guidelines.md` to reflect the implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced global rate limiting for API requests, allowing up to 100 requests per 15-minute window per IP address. Exceeding this limit returns a 429 error with a descriptive message.

- **Documentation**
  - Updated README and project guidelines to document the new rate limiting behavior and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->