### PR TITLE
Remove stas object from Habit

### DIFF
--- a/src/services/habit.service.js
+++ b/src/services/habit.service.js
@@ -63,11 +63,6 @@ async function getHabitsForDate(clerkUserId, dateString, timeZone) {
     icon: habit.icon,
     frequency: habit.frequency.split(','),
     completed: completedHabitIds.has(habit.id),
-    stats: {
-      totalCompletions: habit.total_completions,
-      streak: habit.streak,
-      lastCompleted: habit.last_completed,
-    },
   }));
 
   return results;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed display of habit statistics (such as total completions, streak, and last completed date) from the habit details shown for a selected date. Only basic habit information and completion status are now visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->